### PR TITLE
Change default nls to BYTE

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced_adapter.rb
@@ -440,7 +440,7 @@ module ActiveRecord
         :nls_dual_currency       => nil,
         :nls_iso_currency        => nil,
         :nls_language            => nil,
-        :nls_length_semantics    => 'CHAR',
+        :nls_length_semantics    => 'BYTE',
         :nls_nchar_conv_excp     => nil,
         :nls_numeric_characters  => nil,
         :nls_sort                => nil,


### PR DESCRIPTION
Both staging and production use `BYTE` for data types with VARCHAR2.  Currently all our local db's are using `CHAR` which causes issues loading some records.  For example WM_STYLES and WM_PRODUCT records.